### PR TITLE
fix oracle init threshold, maxUp cap, and interface view

### DIFF
--- a/contracts/DataOracle.sol
+++ b/contracts/DataOracle.sol
@@ -149,6 +149,7 @@ contract DataOracle is  IDataOracle, Initializable, AccessControlUpgradeable {
      */
     function initialize(uint16 _threshold,
         address[] calldata _voters) external initializer {
+        require(_threshold > 0, InvalidThreshold());
         __AccessControl_init();
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
 	for (uint256 i = 0; i < _voters.length; ++i) {
@@ -186,6 +187,7 @@ contract DataOracle is  IDataOracle, Initializable, AccessControlUpgradeable {
      * @param _maxUpPercent - set maximum data
      */
     function setMaxUpPercent(uint16 _maxUpPercent) external onlyRole(DEFAULT_ADMIN_ROLE) {
+       require(!(_maxUpPercent > 100), OutOfBounds());
        maxUpPercent = _maxUpPercent;
        resetVotes();
      }

--- a/contracts/IDataOracle.sol
+++ b/contracts/IDataOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.33;
 
 /**
  * @title IDataOracle
@@ -9,7 +9,7 @@ pragma solidity ^0.8.24;
 interface IDataOracle {
     /**
      * @notice return last update value
-     * @return timestamp  Timestamp of last value
+     * @return value - last stored data
      */
-    function getLastData() external returns (uint256);
+    function getLastData() external view returns (uint256);
 }

--- a/test/MinMax.ts
+++ b/test/MinMax.ts
@@ -93,6 +93,16 @@ describe("DataOracle Min Max", function () {
     }
   });
 
+  it("should revert when max up percent over 100", async function () {
+    try {
+      await dataOracle.write.setMaxUpPercent([101n], {
+        account: owner.account.address,
+      });
+      assert.fail("should have been reverted");
+    } catch (_) {
+    }
+  });
+
   it("should set percent up", async function () {
     const data = 10n**18n;
     await dataOracle.write.setData([data], {

--- a/test/Voting.ts
+++ b/test/Voting.ts
@@ -131,6 +131,18 @@ describe("DataOracle Voting Mechanism", function () {
     };
   });
 
+  it("reject zero threshold at initialize same as setThreshold", async function () {
+    const fresh = await viem.deployContract("DataOracle", []);
+    try {
+      await fresh.write.initialize([0, [user1.account.address]], {
+        account: owner.account.address,
+      });
+      assert.fail("should have reverted");
+    } catch (_) {
+      // InvalidThreshold expected
+    }
+  });
+
   it("should prevent users without VOTER_ROLE from voting", async function () {
     // Try to set data with a user that does not have the VOTER_ROLE
     try {


### PR DESCRIPTION
hey team, went through the core contract and found a few inconsistent bits that are worth tightening.

`initialize` did not reject threshold 0, but `setThreshold` does. With threshold 0 the check `voteCount < threshold` is never true for the first vote (1 < 0 is false), so the first single vote commits data. That is a footgun and does not match how post-deploy config works.

`setMaxDownPercent` already had `<= 100` enforced; `setMaxUpPercent` did not, so you could set an invalid percent and the bound math would not match the intended design. Now both use the same rule.

`IDataOracle` had `getLastData` as non-view and the return NatSpec said timestamp even though the implementation returns the stored value. Fixed the interface to `view` and the doc line.

Tests added for zero threshold at init and for max up over 100.

cheers